### PR TITLE
Develop

### DIFF
--- a/modules/event/timer_event_impl.cpp
+++ b/modules/event/timer_event_impl.cpp
@@ -93,10 +93,10 @@ Loop* TimerEventImpl::getLoop() const
 
 void TimerEventImpl::onEvent()
 {
-    if (mode_ == Mode::kOneshot) {
-        is_enabled_ = false;
-        token_.reset();
-    }
+    // if (mode_ == Mode::kOneshot) {
+    //     is_enabled_ = false;
+    //     token_.reset();
+    // }
 
     wp_loop_->beginEventProcess();
     if (cb_) {
@@ -105,6 +105,11 @@ void TimerEventImpl::onEvent()
         --cb_level_;
     }
     wp_loop_->endEventProcess(this);
+    if (mode_ == Mode::kOneshot) {
+        is_enabled_ = false;
+        token_.reset();
+        cb_ = nullptr;
+    }
 }
 
 }


### PR DESCRIPTION
修复了examples/http/server/async_respond/async_respond.cpp中http异步响应的问题,example中使用TimerPool来管理定时事件,这延长了ctx的生命周期,TimerPool只有在cleanup时才会detete 其中的timer,而给客户端返回respond是通过ctx的析构函数实现的,因此导致无法返回respond. 修复方法,在定时事件执行后,判断是否为OneShot,是则将cb_设置为nullptr,可以将ctx的生命周期提前结束，给客户端回复请求